### PR TITLE
Config Serialization + fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 ## Author Francois Michaut
 ##
 ## Started on  Thu May 26 23:23:59 2022 Francois Michaut
-## Last update Thu Dec  7 10:39:45 2023 Francois Michaut
+## Last update Sun Dec 10 10:17:30 2023 Francois Michaut
 ##
 ## CMakeLists.txt : CMake to build the FileShareProtocol library
 ##
@@ -13,8 +13,6 @@ cmake_minimum_required (VERSION 3.15)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-include(FetchContent)
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
@@ -25,12 +23,7 @@ add_compile_definitions(_GNU_SOURCE)
 project(LibFileShareProtocol VERSION 0.1.0 LANGUAGES C CXX)
 configure_file(include/FileShare/Version.hpp.in FileShare/Version.hpp)
 
-FetchContent_Declare(
-  cppsockets
-  GIT_REPOSITORY  https://github.com/FileShare-Project/libcppsockets.git
-  GIT_TAG         94ac5087f8eca9dd25a1c87e347e16bb9a2168d2
-)
-FetchContent_MakeAvailable(cppsockets)
+add_subdirectory(dependencies)
 
 add_library(fsp
   source/Errors/TransferErrors.cpp
@@ -60,8 +53,12 @@ add_library(fsp
 
 target_include_directories(fsp PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
 target_compile_definitions(fsp PRIVATE _LARGEFILE_SOURCE _FILE_OFFSET_BITS=64)
+target_compile_options(fsp PRIVATE
+  $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wall -Wextra>
+  $<$<CXX_COMPILER_ID:MSVC>:/W4>
+)
 
-target_link_libraries(fsp cppsockets)
+target_link_libraries(fsp cppsockets cereal)
 
 option(LIBFSP_BUILD_TESTS "TRUE to build the libfsp tests" FALSE)
 if(LIBFSP_BUILD_TESTS)

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -1,0 +1,26 @@
+##
+## Project LibFileShareProtocol, 2023
+##
+## Author Francois Michaut
+##
+## Started on  Sun Dec 10 10:27:39 2023 Francois Michaut
+## Last update Sun Dec 10 18:56:37 2023 Francois Michaut
+##
+## CMakeLists.txt : CMake to fetch and build the dependecies of the FileShareProtocol library
+##
+
+include(FetchContent)
+
+FetchContent_Declare(
+  cppsockets
+  GIT_REPOSITORY  https://github.com/FileShare-Project/libcppsockets.git
+  GIT_TAG         7a0bd91b16f6c3aa808e26684916e0dcc935717a
+)
+FetchContent_MakeAvailable(cppsockets)
+
+FetchContent_Declare(
+  cereal
+  GIT_REPOSITORY  https://github.com/f-michaut/cereal.git
+  GIT_TAG         203ba6f75047dd90e961596d6ad742b80d942014
+)
+add_subdirectory(cereal)

--- a/dependencies/cereal/CMakeLists.txt
+++ b/dependencies/cereal/CMakeLists.txt
@@ -1,0 +1,14 @@
+##
+## Project LibFileShareProtocol, 2023
+##
+## Author Francois Michaut
+##
+## Started on  Sun Dec 10 10:29:19 2023 Francois Michaut
+## Last update Sun Dec 10 10:29:24 2023 Francois Michaut
+##
+## CMakeLists.txt : CMake to set build options for cereal dependency
+##
+
+set(JUST_INSTALL_CEREAL ON) # We don't want to build tests or benchmarks
+
+FetchContent_MakeAvailable(cereal)

--- a/include/FileShare/Client.hpp
+++ b/include/FileShare/Client.hpp
@@ -4,7 +4,7 @@
 ** Author Francois Michaut
 **
 ** Started on  Sun Aug 28 09:23:07 2022 Francois Michaut
-** Last update Mon Dec  4 21:55:25 2023 Francois Michaut
+** Last update Sat Dec  9 09:01:57 2023 Francois Michaut
 **
 ** Client.hpp : Client to communicate with peers with the FileShareProtocol
 */
@@ -37,8 +37,8 @@ namespace FileShare {
             void respond_to_request(Protocol::Request, Protocol::StatusCode);
 
             // Blocking functions
-            Protocol::Response<void> send_file(std::string filepath, ProgressCallback progress_callback = [](const std::string &filepath, std::size_t current_size, std::size_t total_size){});
-            Protocol::Response<void> receive_file(std::string filepath, ProgressCallback progress_callback = [](const std::string &filepath, std::size_t current_size, std::size_t total_size){});
+            Protocol::Response<void> send_file(std::string filepath, ProgressCallback progress_callback = [](const std::string &, std::size_t, std::size_t){});
+            Protocol::Response<void> receive_file(std::string filepath, ProgressCallback progress_callback = [](const std::string &, std::size_t, std::size_t){});
             Protocol::Response<std::vector<Protocol::FileInfo>> list_files(std::string folderpath = "");
             // TODO: Async non-blocking Functions
 

--- a/include/FileShare/Config.hpp
+++ b/include/FileShare/Config.hpp
@@ -4,14 +4,14 @@
 ** Author Francois Michaut
 **
 ** Started on  Tue Sep 13 11:23:57 2022 Francois Michaut
-** Last update Wed Dec  6 06:26:43 2023 Francois Michaut
+** Last update Sun Dec 10 17:37:30 2023 Francois Michaut
 **
 ** Config.hpp : Configuration of the file sharing
 */
 
 #pragma once
 
-#include "FileShare/FileMapping.hpp"
+#include "FileShare/Config/FileMapping.hpp"
 
 #include <filesystem>
 #include <vector>
@@ -26,12 +26,12 @@ namespace FileShare {
                                      // on current operation and errors/latency
             };
 
-            // paths starting with '~/' will have this part replaced by the current user's home directory
             Config();
             ~Config() = default;
 
-            static Config from_file(std::filesystem::path config_file);
-            void to_file(std::filesystem::path config_file);
+            // paths starting with '~/' will have this part replaced by the current user's home directory
+            static Config from_file(std::filesystem::path config_file = "~/.fsp/config");
+            void to_file(std::filesystem::path config_file = "~/.fsp/config");
 
             [[nodiscard]] const std::filesystem::path &get_downloads_folder() const;
             Config &set_downloads_folder(const std::filesystem::path path);
@@ -45,9 +45,7 @@ namespace FileShare {
             Config &set_private_keys_dir(std::filesystem::path path);
             Config &set_private_key_name(std::string name);
 
-            [[nodiscard]] const std::string &get_root_name() const;
             [[nodiscard]] TransportMode get_transport_mode() const;
-            Config &set_root_name(std::string root_name);
             Config &set_transport_mode(TransportMode mode);
 
             [[nodiscard]] bool is_server_disabled() const;

--- a/include/FileShare/Config/FileMapping.hpp
+++ b/include/FileShare/Config/FileMapping.hpp
@@ -4,7 +4,7 @@
 ** Author Francois Michaut
 **
 ** Started on  Sun Nov 19 11:23:07 2023 Francois Michaut
-** Last update Wed Dec  6 02:24:38 2023 Francois Michaut
+** Last update Sun Dec 10 17:33:23 2023 Francois Michaut
 **
 ** FileMapping.hpp : Class to hold information about which files are available for listing/download
 */
@@ -27,6 +27,9 @@ namespace FileShare {
             enum Visibility { VISIBLE, HIDDEN };
             using NodeMap = std::unordered_map<std::string, PathNode, FileShare::Utils::string_hash, std::equal_to<>>;
 
+            PathNode() = default;
+            virtual ~PathNode() = default;
+
             static PathNode make_virtual_node(std::string name, Visibility visibility = HIDDEN);
             static PathNode make_virtual_node(std::string name, Visibility visibility, NodeMap child_nodes);
             static PathNode make_virtual_node(std::string name, Visibility visibility, std::vector<PathNode> child_nodes);
@@ -41,6 +44,7 @@ namespace FileShare {
             PathNode &clear_child_nodes();
 
             [[nodiscard]] std::string_view get_name() const;
+            [[nodiscard]] const std::string &get_name_str() const;
             PathNode &set_name(std::string name);
 
             [[nodiscard]] Type get_type() const;
@@ -95,7 +99,8 @@ namespace FileShare {
         public:
             using FilepathSet=std::unordered_set<std::filesystem::path>;
 
-            FileMapping(RootPathNode root_node = {}, FilepathSet forbidden_paths = FileMapping::default_forbidden_paths());
+            FileMapping() = default;
+            FileMapping(RootPathNode root_node, FilepathSet forbidden_paths = FileMapping::default_forbidden_paths());
 
             [[nodiscard]] std::string_view get_root_name() const;
             void set_root_name(std::string root_name);

--- a/include/FileShare/Config/Serialization.hpp
+++ b/include/FileShare/Config/Serialization.hpp
@@ -1,0 +1,129 @@
+/*
+** Project LibFileShareProtocol, 2023
+**
+** Author Francois Michaut
+**
+** Started on  Sun Dec 10 10:56:44 2023 Francois Michaut
+** Last update Sun Dec 10 17:27:40 2023 Francois Michaut
+**
+** Serialization.hpp : FileShare Config serialization functions
+*/
+
+#pragma once
+
+#include "FileShare/Config.hpp"
+
+#include <cereal/cereal.hpp>
+#include <cereal/types/filesystem.hpp>
+#include <cereal/types/string.hpp>
+#include <cereal/types/unordered_map.hpp>
+#include <cereal/types/unordered_set.hpp>
+
+static constexpr std::uint32_t file_share_config_version = 0;
+static constexpr std::uint32_t file_share_file_mapping_version = 0;
+static constexpr std::uint32_t file_share_path_node_version = 0;
+
+CEREAL_CLASS_VERSION(FileShare::Config, file_share_config_version);
+CEREAL_CLASS_VERSION(FileShare::FileMapping, file_share_file_mapping_version);
+CEREAL_CLASS_VERSION(FileShare::RootPathNode, file_share_path_node_version);
+CEREAL_CLASS_VERSION(FileShare::PathNode, file_share_path_node_version);
+
+namespace FileShare {
+    template <class Archive>
+    void save(Archive &ar, const FileShare::Config &config, [[maybe_unused]] const std::uint32_t version)
+    {
+        ar(
+            config.get_transport_mode(),
+            config.get_file_mapping(),
+            config.get_downloads_folder(),
+            config.get_private_keys_dir(),
+            config.get_private_key_name(),
+            config.is_server_disabled()
+        );
+    }
+
+    template <class Archive>
+    void load(Archive &ar, FileShare::Config &config, const std::uint32_t version)
+    {
+        if (version > file_share_config_version) {
+            throw std::runtime_error("Config file format is more recent than what this program supports");
+        }
+
+        FileShare::Config::TransportMode mode;
+        FileShare::FileMapping mapping;
+        std::filesystem::path downloads_folder;
+        std::filesystem::path private_keys_dir;
+        std::string private_key_name;
+        bool server_disabled;
+
+        ar(mode, mapping, downloads_folder, private_keys_dir, private_key_name, server_disabled);
+
+        config.set_transport_mode(mode)
+            .set_file_mapping(std::move(mapping))
+            .set_downloads_folder(std::move(downloads_folder))
+            .set_private_keys_dir(std::move(private_keys_dir))
+            .set_private_key_name(std::move(private_key_name))
+            .set_server_disabled(server_disabled);
+    }
+
+    template <class Archive, typename Node>
+    typename std::enable_if_t<std::is_base_of_v<FileShare::PathNode, Node>, void>
+    save(Archive &ar, const Node &root_node, [[maybe_unused]] const std::uint32_t version)
+    {
+        ar(
+            root_node.get_name_str(),
+            root_node.get_type(),
+            root_node.get_visibility(),
+            root_node.get_host_path(),
+            root_node.get_child_nodes()
+        );
+    }
+
+    template <class Archive, typename Node>
+    typename std::enable_if_t<std::is_base_of_v<FileShare::PathNode, Node>, void>
+    load(Archive &ar, Node &root_node, const std::uint32_t version)
+    {
+        if (version > file_share_path_node_version) {
+            throw std::runtime_error("PathNode file format is more recent than what this program supports");
+        }
+
+        std::string name;
+        PathNode::Type type;
+        PathNode::Visibility visibility;
+        std::filesystem::path host_path;
+        PathNode::NodeMap child_nodes;
+
+        ar(name, type, visibility, host_path, child_nodes);
+
+        root_node.set_name(std::move(name));
+        root_node.set_type(type);
+        root_node.set_visibility(visibility);
+        root_node.set_host_path(std::move(host_path));
+        root_node.set_child_nodes(std::move(child_nodes));
+    }
+
+    template <class Archive>
+    void save(Archive &ar, const FileShare::FileMapping &file_mapping, [[maybe_unused]] const std::uint32_t version)
+    {
+        ar(
+            file_mapping.get_root_node(),
+            file_mapping.get_forbidden_paths()
+        );
+    }
+
+    template <class Archive>
+    void load(Archive &ar, FileShare::FileMapping &file_mapping, const std::uint32_t version)
+    {
+        if (version > file_share_file_mapping_version) {
+            throw std::runtime_error("FileMapping file format is more recent than what this program supports");
+        }
+
+        FileShare::RootPathNode root_node;
+        FileShare::FileMapping::FilepathSet forbidden_paths;
+
+        ar(root_node, forbidden_paths);
+
+        file_mapping.set_root_node(std::move(root_node));
+        file_mapping.set_forbidden_paths(std::move(forbidden_paths));
+    }
+}

--- a/include/FileShare/Protocol/Handler/v0.0.0/ProtocolHandler.hpp
+++ b/include/FileShare/Protocol/Handler/v0.0.0/ProtocolHandler.hpp
@@ -4,7 +4,7 @@
 ** Author Francois Michaut
 **
 ** Started on  Fri May  5 21:32:03 2023 Francois Michaut
-** Last update Thu Aug 24 09:42:01 2023 Francois Michaut
+** Last update Sat Dec  9 08:59:02 2023 Francois Michaut
 **
 ** ProtocolHandler.hpp : ProtocolHandler for the v0.0.0 of the protocol
 */
@@ -17,6 +17,8 @@
 namespace FileShare::Protocol::Handler::v0_0_0 {
     class ProtocolHandler : public IProtocolHandler {
         public:
+            virtual ~ProtocolHandler() = default;
+
             std::string format_send_file(std::uint8_t message_id, const SendFileData &data) override;
             std::string format_receive_file(std::uint8_t message_id, const ReceiveFileData &data) override;
             std::string format_list_files(std::uint8_t message_id, const ListFilesData &data) override;

--- a/include/FileShare/Protocol/RequestData.hpp
+++ b/include/FileShare/Protocol/RequestData.hpp
@@ -4,7 +4,7 @@
 ** Author Francois Michaut
 **
 ** Started on  Sun Jul 16 11:25:51 2023 Francois Michaut
-** Last update Wed Dec  6 05:13:05 2023 Francois Michaut
+** Last update Sat Dec  9 18:54:32 2023 Francois Michaut
 **
 ** RequestData.hpp : RequestData interface. Subclasses will represent every request payload
 */
@@ -24,6 +24,7 @@ namespace FileShare::Protocol {
         public:
             ResponseData() = default;
             ResponseData(StatusCode status);
+            virtual ~ResponseData() = default;
 
             std::string debug_str() const override;
             StatusCode status;
@@ -33,6 +34,7 @@ namespace FileShare::Protocol {
         public:
             SendFileData() = default;
             SendFileData(std::string filepath, Utils::HashAlgorithm hash_algorithm, std::string filehash, std::filesystem::file_time_type last_updated, std::size_t packet_size, std::size_t total_packets);
+            virtual ~SendFileData() = default;
 
             std::string debug_str() const override;
 
@@ -40,14 +42,15 @@ namespace FileShare::Protocol {
             Utils::HashAlgorithm hash_algorithm;
             std::string filehash;
             std::filesystem::file_time_type last_updated;
-            std::size_t total_packets;
             std::size_t packet_size;
+            std::size_t total_packets;
     };
 
     class ReceiveFileData : public IRequestData {
         public:
             ReceiveFileData() = default;
             ReceiveFileData(std::string filepath, std::size_t packet_size, std::size_t packet_start);
+            virtual ~ReceiveFileData() = default;
 
             std::string debug_str() const override;
 
@@ -59,6 +62,7 @@ namespace FileShare::Protocol {
     class ListFilesData : public IRequestData {
         public:
             ListFilesData(std::string folderpath = "");
+            virtual ~ListFilesData() = default;
 
             std::string debug_str() const override;
 
@@ -69,6 +73,7 @@ namespace FileShare::Protocol {
         public:
             FileListData() = default;
             FileListData(std::uint8_t request_id, std::size_t packet_id, std::vector<FileInfo> files = {});
+            virtual ~FileListData() = default;
 
             std::string debug_str() const override;
 
@@ -81,6 +86,7 @@ namespace FileShare::Protocol {
         public:
             DataPacketData() = default;
             DataPacketData(std::uint8_t request_id, std::size_t packet_id, std::string data);
+            virtual ~DataPacketData() = default;
 
             std::string debug_str() const override;
 
@@ -92,6 +98,7 @@ namespace FileShare::Protocol {
     class PingData : public IRequestData {
         public:
             PingData() = default;
+            virtual ~PingData() = default;
 
             std::string debug_str() const override;
     };
@@ -100,6 +107,7 @@ namespace FileShare::Protocol {
         public:
             ApprovalStatusData() = default;
             ApprovalStatusData(std::uint8_t request_message_id, bool status);
+            virtual ~ApprovalStatusData() = default;
 
             std::string debug_str() const override;
 

--- a/include/FileShare/TransferHandler.hpp
+++ b/include/FileShare/TransferHandler.hpp
@@ -4,7 +4,7 @@
 ** Author Francois Michaut
 **
 ** Started on  Thu Aug 24 08:51:14 2023 Francois Michaut
-** Last update Wed Dec  6 05:20:00 2023 Francois Michaut
+** Last update Sat Dec  9 08:49:52 2023 Francois Michaut
 **
 ** TransferHandler.hpp : Classes to handle the file transfers
 */
@@ -33,6 +33,7 @@ namespace FileShare {
     class DownloadTransferHandler : public IFileTransferHandler {
         public:
             DownloadTransferHandler(std::string destination_filename, std::shared_ptr<Protocol::SendFileData> original_request);
+            virtual ~DownloadTransferHandler() = default;
 
             void receive_packet(const Protocol::DataPacketData &data);
 
@@ -52,6 +53,10 @@ namespace FileShare {
     class UploadTransferHandler : public IFileTransferHandler {
         public:
             UploadTransferHandler(std::string filepath, std::shared_ptr<Protocol::SendFileData> original_request, std::size_t packet_start);
+            UploadTransferHandler(UploadTransferHandler &&other) noexcept = default;
+            virtual ~UploadTransferHandler() = default;
+
+            UploadTransferHandler &operator=(UploadTransferHandler &&other) noexcept = default;
 
             std::shared_ptr<Protocol::DataPacketData> get_next_packet(Protocol::MessageID original_request_id);
 
@@ -64,6 +69,7 @@ namespace FileShare {
     class ListFilesTransferHandler : public ITransferHandler {
         public:
             ListFilesTransferHandler(std::filesystem::path requested_path, FileMapping &file_mapping, std::size_t packet_size);
+            virtual ~ListFilesTransferHandler() = default;
 
             std::shared_ptr<Protocol::FileListData> get_next_packet(Protocol::MessageID original_request_id);
 
@@ -84,6 +90,7 @@ namespace FileShare {
     class FileListTransferHandler : public ITransferHandler {
         public:
             FileListTransferHandler() = default;
+            virtual ~FileListTransferHandler() = default;
 
             void receive_packet(Protocol::FileListData data);
 

--- a/include/FileShare/Utils/DebugPerf.hpp
+++ b/include/FileShare/Utils/DebugPerf.hpp
@@ -4,7 +4,7 @@
 ** Author Francois Michaut
 **
 ** Started on  Tue May  9 10:08:36 2023 Francois Michaut
-** Last update Tue Jul 18 22:03:13 2023 Francois Michaut
+** Last update Sun Dec 10 18:43:47 2023 Francois Michaut
 **
 ** DebugPerf.hpp : A helper class to display time spent in functions or other scopes
 */
@@ -37,7 +37,7 @@ namespace FileShare::Utils {
 #else
     class DebugPerf {
         public:
-            DebugPerf(std::string name) {}
+            DebugPerf(std::string) {}
     };
 #endif
 }

--- a/source/Client.cpp
+++ b/source/Client.cpp
@@ -4,7 +4,7 @@
 ** Author Francois Michaut
 **
 ** Started on  Mon Aug 29 20:50:53 2022 Francois Michaut
-** Last update Wed Dec  6 11:02:26 2023 Francois Michaut
+** Last update Sun Dec 10 18:46:14 2023 Francois Michaut
 **
 ** Client.cpp : Implementation of the FileShareProtocol Client
 */
@@ -87,6 +87,7 @@ namespace FileShare {
                 if (handler.finished()) {
                     m_download_transfers.erase(data->request_id);
                 }
+                break;
             }
             case Protocol::CommandCode::SEND_FILE: {
                 std::shared_ptr<Protocol::SendFileData> data = std::dynamic_pointer_cast<Protocol::SendFileData>(request.request);
@@ -124,6 +125,7 @@ namespace FileShare {
                 auto &handler = m_file_list_transfers.at(data->request_id);
 
                 handler.receive_packet(*data);
+                break;
             }
             default:
                 break;
@@ -144,7 +146,7 @@ namespace FileShare {
         // TODO: handle APPROVAL_PENDING
         if (status != Protocol::StatusCode::STATUS_OK) {
             m_upload_transfers.erase(result);
-            return {status};
+            return {status, {}};
         }
         while (!upload_handler.finished()) {
             if (m_message_queue.available_send_slots() > 0) {
@@ -159,7 +161,7 @@ namespace FileShare {
             }
         }
 
-        return {status}; // TODO
+        return {status, {}}; // TODO
     }
 
     Protocol::Response<void> Client::receive_file(std::string filepath, ProgressCallback progress_callback) {
@@ -171,7 +173,7 @@ namespace FileShare {
 
         // TODO: handle APPROVAL_PENDING
         if (status != Protocol::StatusCode::STATUS_OK) {
-            return {status};
+            return {status, {}};
         }
 
         auto incomming_requests = m_message_queue.get_incomming_requests();
@@ -193,7 +195,7 @@ namespace FileShare {
             poll_requests(); // TODO: currently blocking, but if it changes, needs to add a poll() call to avoid spamming loop
         }
 
-        return {status}; // TODO
+        return {status, {}}; // TODO
     }
 
     Protocol::Response<std::vector<Protocol::FileInfo>> Client::list_files(std::string folderpath) {

--- a/source/Client_private.cpp
+++ b/source/Client_private.cpp
@@ -4,7 +4,7 @@
 ** Author Francois Michaut
 **
 ** Started on  Mon Oct 23 21:33:10 2023 Francois Michaut
-** Last update Wed Dec  6 05:40:01 2023 Francois Michaut
+** Last update Sun Dec 10 18:47:02 2023 Francois Michaut
 **
 ** Client_private.cpp : Private functions of Client implementation
 */
@@ -187,7 +187,7 @@ namespace FileShare {
     }
 
     Protocol::MessageID Client::send_request(Protocol::CommandCode command, std::shared_ptr<Protocol::IRequestData> request_data) {
-        return send_request({command, request_data});
+        return send_request({command, request_data, 0});
     }
 
     Protocol::MessageID Client::send_request(Protocol::Request request) {
@@ -260,7 +260,7 @@ namespace FileShare {
                 std::forward_as_tuple(m_config.get_downloads_folder() / m_device_uuid / filepath.relative_path(), data)
             ).first;
             send_reply(request_id, Protocol::StatusCode::STATUS_OK);
-        } catch (Errors::Transfer::UpToDateError) {
+        } catch (Errors::Transfer::UpToDateError &) {
             send_reply(request_id, Protocol::StatusCode::UP_TO_DATE);
         }
         return result;

--- a/source/Config.cpp
+++ b/source/Config.cpp
@@ -4,15 +4,20 @@
 ** Author Francois Michaut
 **
 ** Started on  Tue Sep 13 11:29:35 2022 Francois Michaut
-** Last update Fri Dec  1 19:39:11 2023 Francois Michaut
+** Last update Sun Dec 10 17:46:39 2023 Francois Michaut
 **
 ** FileShareConfig.cpp : FileShareConfig implementation
 */
 
 #include "FileShare/Config.hpp"
+#include "FileShare/Config/Serialization.hpp"
 #include "FileShare/Utils/Path.hpp"
 
 #include <CppSockets/OSDetection.hpp>
+
+#include <cereal/archives/binary.hpp>
+
+#include <fstream>
 
 namespace FileShare {
     const std::filesystem::perms Config::secure_file_perms = std::filesystem::perms::owner_read | std::filesystem::perms::owner_write;
@@ -36,20 +41,38 @@ namespace FileShare {
         }
     }
 
-    // static Config Config::from_file(std::filesystem::path config_file);
-    // Config &Config::to_file(std::filesystem::path config_file);
+    Config Config::from_file(std::filesystem::path config_file) {
+        config_file = FileShare::Utils::resolve_home_component(config_file);
+        Config new_config;
+        std::ifstream file(config_file, std::ios_base::binary | std::ios_base::in);
+        cereal::BinaryInputArchive ar(file);
+
+        ar(new_config);
+        return new_config;
+    }
+
+    void Config::to_file(std::filesystem::path config_file) {
+        config_file = FileShare::Utils::resolve_home_component(config_file);
+        std::ofstream file(config_file, std::ios_base::binary | std::ios_base::out | std::ios_base::trunc);
+        cereal::BinaryOutputArchive ar(file);
+
+        ar(*this);
+    }
 
     const std::filesystem::path &Config::get_downloads_folder() const { return m_downloads_folder; }
-    // Config &Config::set_downloads_folder(const std::filesystem::path path);
+    Config &Config::set_downloads_folder(std::filesystem::path path) { m_downloads_folder = std::move(path); return *this; }
 
     const std::filesystem::path &Config::get_private_keys_dir() const { return m_private_keys_dir; }
     const std::string &Config::get_private_key_name() const { return m_private_key_name; }
-    // Config &Config::set_private_keys_dir(std::filesystem::path path);
-    // Config &Config::set_private_key_name(std::string name);
+    Config &Config::set_private_keys_dir(std::filesystem::path path) { m_private_keys_dir = std::move(path); return *this; }
+    Config &Config::set_private_key_name(std::string name) { m_private_key_name = std::move(name); return *this; }
 
     Config &Config::set_file_mapping(FileMapping mapping) { m_filemap = mapping; return *this; }
     const FileMapping &Config::get_file_mapping() const { return m_filemap; }
     FileMapping &Config::get_file_mapping() { return m_filemap; }
+
+    Config::TransportMode Config::get_transport_mode() const { return m_transport_mode; }
+    Config &Config::set_transport_mode(TransportMode mode) { m_transport_mode = mode; return *this; }
 
     bool Config::is_server_disabled() const { return m_disable_server; }
     Config &Config::set_server_disabled(bool disabled) { m_disable_server = disabled; return *this; }

--- a/source/Config/FileMapping.cpp
+++ b/source/Config/FileMapping.cpp
@@ -4,7 +4,7 @@
 ** Author Francois Michaut
 **
 ** Started on  Thu Nov 16 22:14:51 2023 Francois Michaut
-** Last update Thu Dec  7 11:01:58 2023 Francois Michaut
+** Last update Sun Dec 10 17:48:38 2023 Francois Michaut
 **
 ** FileMapping.cpp : Config's PathNode implementation
 */
@@ -123,7 +123,9 @@ namespace FileShare {
     PathNode::NodeMap &PathNode::get_child_nodes() { return m_child_nodes; }
     const PathNode::NodeMap &PathNode::get_child_nodes() const { return m_child_nodes; }
     PathNode &PathNode::set_child_nodes(NodeMap nodes) {
-        assert_virtual_type(m_type);
+        if (!nodes.empty()) {
+            assert_virtual_type(m_type);
+        }
         m_child_nodes = std::move(nodes);
         return *this;
     }
@@ -134,6 +136,7 @@ namespace FileShare {
     }
 
     std::string_view PathNode::get_name() const { return m_name; }
+    const std::string &PathNode::get_name_str() const { return m_name; }
     PathNode &PathNode::set_name(std::string name) {
         assert_valid_name(name);
         m_name = std::move(name);
@@ -164,7 +167,9 @@ namespace FileShare {
 
     const std::filesystem::path &PathNode::get_host_path() const { return m_host_path; }
     PathNode &PathNode::set_host_path(std::filesystem::path host_path) {
-        assert_not_virtual_type(m_type);
+        if (!host_path.empty()) {
+            assert_not_virtual_type(m_type);
+        }
         m_host_path = std::move(host_path);
         return *this;
     }

--- a/source/Errors/TransferErrors.cpp
+++ b/source/Errors/TransferErrors.cpp
@@ -4,7 +4,7 @@
 ** Author Francois Michaut
 **
 ** Started on  Sun Oct 22 13:51:24 2023 Francois Michaut
-** Last update Thu Nov 23 18:32:27 2023 Francois Michaut
+** Last update Sat Dec  9 08:57:23 2023 Francois Michaut
 **
 ** TransferErrors.cpp : Transfer related errors implementation
 */
@@ -13,7 +13,7 @@
 
 namespace FileShare::Errors::Transfer {
     UpToDateError::UpToDateError(const char *filename) :
-        UpToDateError(std::move(std::string(filename)))
+        UpToDateError(std::string(filename))
     {}
 
     UpToDateError::UpToDateError(std::string filename) :

--- a/source/Protocol/Handler/v0.0.0/ProtocolHandler.cpp
+++ b/source/Protocol/Handler/v0.0.0/ProtocolHandler.cpp
@@ -4,7 +4,7 @@
 ** Author Francois Michaut
 **
 ** Started on  Fri May  5 21:35:06 2023 Francois Michaut
-** Last update Mon Dec  4 19:18:12 2023 Francois Michaut
+** Last update Sat Dec  9 08:58:26 2023 Francois Michaut
 **
 ** ProtocolHandler.cpp : ProtocolHandler for the v0.0.0 of the protocol
 */
@@ -410,7 +410,6 @@ namespace FileShare::Protocol::Handler::v0_0_0 {
     std::shared_ptr<IRequestData> ProtocolHandler::parse_data_packet(std::string_view payload) {
         DataPacketData data;
         Utils::VarInt varint;
-        std::size_t nb_items;
 
         data.request_id = payload[0];
         payload = payload.substr(1);
@@ -430,7 +429,7 @@ namespace FileShare::Protocol::Handler::v0_0_0 {
     // |     4     | |        1       | |       1      | |    MAX(8)    |
     // |   STRING  | |      ENUM      | |       -      | |    VARINT    |
     // ------------------------------------------------------------------
-    std::string ProtocolHandler::format_ping(std::uint8_t message_id, const PingData &data) {
+    std::string ProtocolHandler::format_ping(std::uint8_t message_id, [[maybe_unused]] const PingData &data) {
         std::string result;
         static const Utils::VarInt payload_size = 0;
 
@@ -442,7 +441,7 @@ namespace FileShare::Protocol::Handler::v0_0_0 {
         return result;
     }
 
-    std::shared_ptr<IRequestData> ProtocolHandler::parse_ping(std::string_view payload) {
+    std::shared_ptr<IRequestData> ProtocolHandler::parse_ping([[maybe_unused]] std::string_view payload) {
         return std::make_shared<PingData>();
     }
 }

--- a/source/Protocol/RequestData.cpp
+++ b/source/Protocol/RequestData.cpp
@@ -4,7 +4,7 @@
 ** Author Francois Michaut
 **
 ** Started on  Tue Jul 18 22:04:57 2023 Francois Michaut
-** Last update Wed Dec  6 05:24:16 2023 Francois Michaut
+** Last update Sat Dec  9 09:01:16 2023 Francois Michaut
 **
 ** RequestData.cpp : RequestData implementation for the requests payloads
 */
@@ -14,16 +14,6 @@
 #include "FileShare/Utils/Time.hpp"
 
 #include <sstream>
-
-static std::string debug_str(FileShare::Protocol::Page page) {
-    std::stringstream ss;
-
-    ss << "Page{"
-       << "total = " << page.total
-       << ", current = " << page.current
-       << "}";
-    return ss.str();
-}
 
 namespace FileShare::Protocol {
     ResponseData::ResponseData(StatusCode status) :
@@ -43,7 +33,7 @@ namespace FileShare::Protocol {
     {}
 
     FileListData::FileListData(std::uint8_t request_id, std::size_t packet_id, std::vector<FileInfo> files) :
-        request_id(request_id), files(files), packet_id(packet_id)
+        request_id(request_id), packet_id(packet_id), files(files)
     {}
 
     DataPacketData::DataPacketData(std::uint8_t request_id, std::size_t packet_id, std::string data) :

--- a/source/Server.cpp
+++ b/source/Server.cpp
@@ -4,7 +4,7 @@
 ** Author Francois Michaut
 **
 ** Started on  Sun Nov  6 21:06:10 2022 Francois Michaut
-** Last update Wed Dec  6 06:27:53 2023 Francois Michaut
+** Last update Sun Dec 10 18:07:06 2023 Francois Michaut
 **
 ** Server.cpp : Server implementation
 */
@@ -70,6 +70,7 @@ namespace FileShare {
         return insert_client(std::move(client));
     }
 
+    Config &Server::get_config() { return m_config; }
     const Config &Server::get_config() const { return m_config; }
     void Server::set_config(const Config &config) { m_config = config; }
     const CppSockets::TlsSocket &Server::get_socket() const { return m_socket; }

--- a/source/TransferHandler.cpp
+++ b/source/TransferHandler.cpp
@@ -4,7 +4,7 @@
 ** Author Francois Michaut
 **
 ** Started on  Thu Aug 24 19:36:36 2023 Francois Michaut
-** Last update Thu Dec  7 11:09:56 2023 Francois Michaut
+** Last update Sat Dec  9 09:03:46 2023 Francois Michaut
 **
 ** TransferHandler.cpp : Implementation of classes to handle the file transfers
 */
@@ -172,7 +172,7 @@ namespace FileShare {
             case PathNode::HOST_FOLDER: {
                 const auto end = std::filesystem::directory_iterator();
 
-                for (int i = 0; m_directory_iterator != end && i < max_count; i++) {
+                for (std::size_t i = 0; m_directory_iterator != end && i < max_count; i++) {
                     auto filepath = m_requested_path / m_directory_iterator->path().filename();
                     auto file_type = m_directory_iterator->is_directory() ? Protocol::FileType::DIRECTORY : Protocol::FileType::FILE;
 
@@ -196,7 +196,7 @@ namespace FileShare {
             case PathNode::VIRTUAL: {
                 const auto &nodes = m_path_node->get_child_nodes();
 
-                for (int i = 0; i < max_count && m_node_iterator != nodes.end(); i++) {
+                for (std::size_t i = 0; i < max_count && m_node_iterator != nodes.end(); i++) {
                     const PathNode &node = m_node_iterator->second;
                     auto file_type = node.is_host_file() ? Protocol::FileType::FILE : Protocol::FileType::DIRECTORY;
 

--- a/source/Utils/FileHash.cpp
+++ b/source/Utils/FileHash.cpp
@@ -4,7 +4,7 @@
 ** Author Francois Michaut
 **
 ** Started on  Sat May  6 22:13:15 2023 Francois Michaut
-** Last update Thu Nov 23 22:49:48 2023 Francois Michaut
+** Last update Sun Dec 10 18:45:08 2023 Francois Michaut
 **
 ** FileHash.cpp : Function to hash file contents
 */
@@ -40,7 +40,7 @@ namespace FileShare::Utils {
         unsigned char digest_buff[EVP_MAX_MD_SIZE];
         unsigned int output_size;
         FileHandle file(path, "r");
-        std::size_t ret = READ_SIZE;
+        std::int64_t ret = READ_SIZE;
         std::vector<char> buff(READ_SIZE);
 
 #if defined(OS_UNIX) && !defined(OS_APPLE)

--- a/tests/Config/TestFileMapping.cpp
+++ b/tests/Config/TestFileMapping.cpp
@@ -4,12 +4,12 @@
 ** Author Francois Michaut
 **
 ** Started on  Wed Nov 22 20:19:02 2023 Francois Michaut
-** Last update Wed Dec  6 02:46:41 2023 Francois Michaut
+** Last update Sun Dec 10 10:59:02 2023 Francois Michaut
 **
 ** TestFileMapping.cpp : FileMapping classes implementation
 */
 
-#include "FileShare/FileMapping.hpp"
+#include "FileShare/Config/FileMapping.hpp"
 
 #include <cassert>
 


### PR DESCRIPTION
- Moved FetchContent declarations to a dependecies/ subdir, to ease customization of each dependecy
- Added extra compiler warnings
- Fixed most of the warnings
- Added cereal lib for serialization, and defined functions to serialize Config objects with cereal
- Implemented to_file and from_file for Config with cereal